### PR TITLE
Fix K8s Service port config by adding named ports and exposing issuer endpoint

### DIFF
--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -11,6 +11,11 @@ spec:
   selector:
     app: userservice
   ports:
-    - port: 80
+    - name: http
+      port: 80
+      targetPort: 8081
+      protocol: TCP
+    - name: issuer
+      port: 8081
       targetPort: 8081
       protocol: TCP


### PR DESCRIPTION
## Summary
- Added `name: http` to the existing port 80 mapping
- Added explicit `targetPort: 8081` on the HTTP port entry
- Added a second named port `issuer` mapping Service port `8081` → container port `8081`

Closes #32