### PR TITLE
Add Helm chart for userservice Kubernetes deployment

### DIFF
--- a/helm/userservice/Chart.yaml
+++ b/helm/userservice/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: userservice
+description: Helm chart for VibeVault User Service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/userservice/templates/NOTES.txt
+++ b/helm/userservice/templates/NOTES.txt
@@ -1,0 +1,20 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+To check the status of your deployment:
+
+  kubectl get deployments -n {{ .Release.Namespace }}
+
+To access the userservice:
+
+  kubectl port-forward svc/{{ include "userservice.fullname" . }} {{ .Values.containerPort }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+
+{{- if .Values.mysql.enabled }}
+
+MySQL is enabled and deployed as part of this release.
+To check MySQL status:
+
+  kubectl get pods -l app={{ include "userservice.fullname" . }}-mysql -n {{ .Release.Namespace }}
+{{- end }}

--- a/helm/userservice/templates/_helpers.tpl
+++ b/helm/userservice/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Chart name.
+*/}}
+{{- define "userservice.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name.
+*/}}
+{{- define "userservice.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart label.
+*/}}
+{{- define "userservice.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "userservice.labels" -}}
+app: {{ include "userservice.name" . }}
+version: v1
+part-of: vibevault
+helm.sh/chart: {{ include "userservice.chart" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "userservice.selectorLabels" -}}
+app: {{ include "userservice.name" . }}
+{{- end }}

--- a/helm/userservice/templates/configmap.yaml
+++ b/helm/userservice/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "userservice.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "userservice.labels" . | nindent 4 }}
+data:
+  PORT: {{ .Values.containerPort | quote }}
+  DB_URL: {{ .Values.config.dbUrl | default (printf "jdbc:mysql://%s-mysql:3306/userservice?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC" (include "userservice.fullname" .)) | quote }}
+  ADMIN_EMAIL: {{ .Values.config.adminEmail | quote }}
+  ADMIN_FIRST_NAME: {{ .Values.config.adminFirstName | quote }}
+  ADMIN_LAST_NAME: {{ .Values.config.adminLastName | quote }}
+  CLIENT_ID: {{ .Values.config.clientId | quote }}
+  REDIRECT_URI: {{ .Values.config.redirectUri | quote }}
+  ISSUER_URI: {{ .Values.config.issuerUri | quote }}
+  SPRING_PROFILES_ACTIVE: {{ .Values.config.springProfilesActive | quote }}

--- a/helm/userservice/templates/deployment.yaml
+++ b/helm/userservice/templates/deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "userservice.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "userservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "userservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "userservice.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "userservice.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "userservice.fullname" . }}-config
+            - secretRef:
+                name: {{ include "userservice.fullname" . }}-secret
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/helm/userservice/templates/mysql-deployment.yaml
+++ b/helm/userservice/templates/mysql-deployment.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "userservice.fullname" . }}-mysql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "userservice.fullname" . }}-mysql
+    part-of: vibevault
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "userservice.fullname" . }}-mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: {{ include "userservice.fullname" . }}-mysql
+        part-of: vibevault
+    spec:
+      containers:
+        - name: mysql
+          image: {{ .Values.mysql.image }}
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_DATABASE
+              value: userservice
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "userservice.fullname" . }}-secret
+                  key: DB_PASSWORD
+          resources:
+            requests:
+              cpu: {{ .Values.mysql.resources.requests.cpu }}
+              memory: {{ .Values.mysql.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.mysql.resources.limits.cpu }}
+              memory: {{ .Values.mysql.resources.limits.memory }}
+          volumeMounts:
+            - name: mysql-storage
+              mountPath: /var/lib/mysql
+          readinessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - "127.0.0.1"
+                - --protocol=TCP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - mysqladmin
+                - ping
+                - -h
+                - "127.0.0.1"
+                - --protocol=TCP
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+      volumes:
+        - name: mysql-storage
+          persistentVolumeClaim:
+            claimName: {{ include "userservice.fullname" . }}-mysql-pvc
+{{- end }}

--- a/helm/userservice/templates/mysql-pvc.yaml
+++ b/helm/userservice/templates/mysql-pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "userservice.fullname" . }}-mysql-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "userservice.fullname" . }}-mysql
+    part-of: vibevault
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.mysql.storage }}
+{{- end }}

--- a/helm/userservice/templates/mysql-service.yaml
+++ b/helm/userservice/templates/mysql-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mysql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "userservice.fullname" . }}-mysql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "userservice.fullname" . }}-mysql
+    part-of: vibevault
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "userservice.fullname" . }}-mysql
+  ports:
+    - port: 3306
+      targetPort: 3306
+      protocol: TCP
+{{- end }}

--- a/helm/userservice/templates/namespace.yaml
+++ b/helm/userservice/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    name: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/userservice/templates/secret.yaml
+++ b/helm/userservice/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "userservice.fullname" . }}-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "userservice.labels" . | nindent 4 }}
+type: Opaque
+data:
+  DB_USERNAME: {{ .Values.secrets.dbUsername | b64enc | quote }}
+  DB_PASSWORD: {{ .Values.secrets.dbPassword | b64enc | quote }}
+  ADMIN_PASSWORD: {{ .Values.secrets.adminPassword | b64enc | quote }}
+  CLIENT_SECRET: {{ .Values.secrets.clientSecret | b64enc | quote }}

--- a/helm/userservice/templates/service.yaml
+++ b/helm/userservice/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "userservice.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "userservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "userservice.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP
+    - name: issuer
+      port: {{ .Values.containerPort }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP

--- a/helm/userservice/values.yaml
+++ b/helm/userservice/values.yaml
@@ -1,0 +1,58 @@
+replicaCount: 2
+
+image:
+  repository: userservice
+  tag: latest
+  pullPolicy: IfNotPresent
+
+containerPort: 8081
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+config:
+  # Leave empty to auto-generate from mysql service name.
+  # Override for external DB scenarios.
+  # dbUrl: ""
+  adminEmail: "admin@gmail.com"
+  adminFirstName: "Admin"
+  adminLastName: "User"
+  clientId: "vibevault-client"
+  redirectUri: "https://oauth.pstmn.io/v1/callback"
+  issuerUri: "http://userservice:8081"
+  springProfilesActive: "default"
+
+secrets:
+  dbUsername: "root"
+  dbPassword: "IFuckingLoveMySql@2025"
+  adminPassword: "abcd@1234"
+  clientSecret: "abc@12345"
+
+mysql:
+  enabled: true
+  image: "mysql:8.0"
+  storage: 1Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 768Mi
+
+createNamespace: false


### PR DESCRIPTION
## Summary

This converts the raw k8s/ manifests into a proper Helm chart under helm/userservice/. The chart parameterizes everything through values.yaml while staying faithful to the existing manifests.

Key things worth noting: DB_URL is dynamically templated using the Helm fullname helper so it stays correct regardless of release name, secrets use b64enc instead of hardcoded base64, and the rollingUpdate block only renders when the strategy type is actually RollingUpdate. The service keeps both named ports (http on 80 and issuer on 8081) that the userservice needs for OAuth2 token issuance.

MySQL resources and namespace creation can both be toggled off through values for environments where they're managed externally.

Closes #36

## Test plan

1. Run `helm lint helm/userservice/` and confirm it passes
2. Run `helm template test helm/userservice/ -n vibevault` and compare against existing k8s/ manifests
3. Set `mysql.enabled: false` and verify MySQL resources are excluded
4. Set `createNamespace: true` and verify namespace resource renders
5. Confirm secrets are b64enc'd, not hardcoded base64
6. Change the release name and verify DB_URL hostname updates accordingly
7. Set strategy type to Recreate and verify rollingUpdate block is omitted
8. Confirm service has both http (port 80) and issuer (port 8081) ports