### PR TITLE
Exclude Spring Security auto-config in seed profile

### DIFF
--- a/src/main/resources/application-seed.yaml
+++ b/src/main/resources/application-seed.yaml
@@ -1,6 +1,11 @@
 spring:
   main:
     web-application-type: none
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.server.servlet.OAuth2AuthorizationServerAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
   datasource:
     hikari:
       maximum-pool-size: 5


### PR DESCRIPTION
## Summary
- Excludes `SecurityAutoConfiguration`, `OAuth2AuthorizationServerAutoConfiguration`, and `OAuth2ResourceServerAutoConfiguration` in the `seed` Spring profile
- Preemptive fix: same issue that caused productservice seed job to fail (Spring Security beans initialize even with `web-application-type: none`)

## Test plan
- [ ] Deploy via deploy pipeline (rebuilds Docker image)
- [ ] Re-run seed job — should still complete successfully