### PR TITLE
Fix seed profile: exclude SecurityConfig and fix job wait logic

### DIFF
--- a/.github/workflows/seed.yaml
+++ b/.github/workflows/seed.yaml
@@ -52,13 +52,19 @@ jobs:
 
       - name: Wait for seed job to complete
         run: |
-          kubectl wait --for=condition=complete --for=condition=failed job/seed-users -n vibevault --timeout=600s
-          STATUS=$(kubectl get job seed-users -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
-          if [ "$STATUS" != "True" ]; then
-            echo "Seed job failed!"
-            exit 1
-          fi
+          while true; do
+            COMPLETE=$(kubectl get job seed-users -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null)
+            FAILED=$(kubectl get job seed-users -n vibevault -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null)
+            if [ "$COMPLETE" = "True" ]; then
+              echo "Seed job completed successfully."
+              break
+            elif [ "$FAILED" = "True" ]; then
+              echo "Seed job failed!"
+              exit 1
+            fi
+            sleep 5
+          done
 
       - name: Print seed job logs
         if: always()
-        run: kubectl logs job/seed-users -n vibevault
+        run: kubectl logs job/seed-users -n vibevault --pod-running-timeout=10s 2>&1 || echo "Could not retrieve logs (pod may have been cleaned up)"

--- a/src/main/java/com/vibevault/userservice/security/SecurityConfig.java
+++ b/src/main/java/com/vibevault/userservice/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.vibevault.userservice.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.OAuth2AuthorizationServerConfiguration;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.authorization.OAuth2AuthorizationServerConfigurer;
@@ -47,6 +48,7 @@ import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 
 @Configuration
 @EnableWebSecurity
+@Profile("!seed")
 public class SecurityConfig {
 
     @Bean


### PR DESCRIPTION
## Summary
- Adds `@Profile("!seed")` to `SecurityConfig` — preemptive fix matching productservice (same `@EnableWebSecurity` issue)
- Replaces broken `kubectl wait --for=condition=complete --for=condition=failed` with a polling loop — multiple `--for` flags use AND logic (not OR), causing the wait step to hang forever
- Adds `--pod-running-timeout` fallback to the logs step

## Root cause
- **kubectl wait**: Multiple `--for` flags require ALL conditions to be true simultaneously. A job can never be both `Complete` and `Failed`.

## Test plan
- [ ] Deploy via deploy pipeline (rebuild image with `@Profile` fix)
- [ ] Re-run seed job — pipeline should exit promptly