### PR TITLE
Fix docker-compose: add RSA key support for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ build/
 
 ## Coverage Reports ##
 coverageReport/
+
+## JWT keys (local dev only) ##
+*.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,17 @@ services:
       CLIENT_SECRET: abc@12345
       REDIRECT_URI: https://oauth.pstmn.io/v1/callback
       ISSUER_URI: http://userservice:8081
+    volumes:
+      - ./jwt-private.pem:/app/keys/jwt-private.pem:ro
+      - ./jwt-public.pem:/app/keys/jwt-public.pem:ro
+    entrypoint: >
+      sh -c '
+      RSA_PRIVATE_KEY=$$(cat /app/keys/jwt-private.pem) &&
+      export RSA_PRIVATE_KEY &&
+      RSA_PUBLIC_KEY=$$(cat /app/keys/jwt-public.pem) &&
+      export RSA_PUBLIC_KEY &&
+      exec java $$JAVA_OPTS -jar app.jar
+      '
     ports:
       - "8081:8081"
     depends_on:


### PR DESCRIPTION
## Summary
- Mount locally generated PEM files into the container via volumes
- Use entrypoint wrapper to read PEM files into env vars at startup
- Add `*.pem` to `.gitignore` to prevent accidental commit of keys

## Test plan
- [x] Generate RSA keys: `openssl genrsa -out jwt-private.pem 2048 && openssl rsa -in jwt-private.pem -pubout -out jwt-public.pem && chmod 644 *.pem`
- [x] `docker compose up -d` — userservice starts and becomes healthy
- [x] OAuth2 token flow works (`/oauth2/authorize` → `/oauth2/token`)

Fixes #51